### PR TITLE
Fix empty queryParameters.payload in the request sent from Dialogflow to the fulfillment webhook

### DIFF
--- a/botlib/dialogflow_session_client.js
+++ b/botlib/dialogflow_session_client.js
@@ -17,6 +17,7 @@
  * @fileoverview Contacts dialogflow and returns response.
  */
 const dialogflow = require('dialogflow');
+const jsonToProto = require('./json_to_proto')
 module.exports = class DialogflowSessionClient {
 
   constructor(projectId){
@@ -34,7 +35,7 @@ module.exports = class DialogflowSessionClient {
         }
       },
       queryParams: {
-        payload: payload
+        payload: jsonToProto.jsonToStructProto(payload)
       }
     };
   }

--- a/botlib/json_to_proto.js
+++ b/botlib/json_to_proto.js
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2017, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Utilities for converting between JSON and goog.protobuf.Struct
+ * proto.
+ */
+
+'use strict';
+
+function jsonToStructProto(json) {
+  const fields = {};
+  for (const k in json) {
+    fields[k] = jsonValueToProto(json[k]);
+  }
+
+  return {fields};
+}
+
+const JSON_SIMPLE_TYPE_TO_PROTO_KIND_MAP = {
+  [typeof 0]: 'numberValue',
+  [typeof '']: 'stringValue',
+  [typeof false]: 'boolValue',
+};
+
+const JSON_SIMPLE_VALUE_KINDS = new Set([
+  'numberValue',
+  'stringValue',
+  'boolValue',
+]);
+
+function jsonValueToProto(value) {
+  const valueProto = {};
+
+  if (value === null) {
+    valueProto.kind = 'nullValue';
+    valueProto.nullValue = 'NULL_VALUE';
+  } else if (value instanceof Array) {
+    valueProto.kind = 'listValue';
+    valueProto.listValue = {values: value.map(jsonValueToProto)};
+  } else if (typeof value === 'object') {
+    valueProto.kind = 'structValue';
+    valueProto.structValue = jsonToStructProto(value);
+  } else if (typeof value in JSON_SIMPLE_TYPE_TO_PROTO_KIND_MAP) {
+    const kind = JSON_SIMPLE_TYPE_TO_PROTO_KIND_MAP[typeof value];
+    valueProto.kind = kind;
+    valueProto[kind] = value;
+  } else {
+    console.warn('Unsupported value type ', typeof value);
+  }
+  return valueProto;
+}
+
+function structProtoToJson(proto) {
+  if (!proto || !proto.fields) {
+    return {};
+  }
+  const json = {};
+  for (const k in proto.fields) {
+    json[k] = valueProtoToJson(proto.fields[k]);
+  }
+  return json;
+}
+
+function valueProtoToJson(proto) {
+  if (!proto || !proto.kind) {
+    return null;
+  }
+
+  if (JSON_SIMPLE_VALUE_KINDS.has(proto.kind)) {
+    return proto[proto.kind];
+  } else if (proto.kind === 'nullValue') {
+    return null;
+  } else if (proto.kind === 'listValue') {
+    if (!proto.listValue || !proto.listValue.values) {
+      console.warn('Invalid JSON list value proto: ', JSON.stringify(proto));
+    }
+    return proto.listValue.values.map(valueProtoToJson);
+  } else if (proto.kind === 'structValue') {
+    return structProtoToJson(proto.structValue);
+  } else {
+    console.warn('Unsupported JSON value proto kind: ', proto.kind);
+    return null;
+  }
+}
+
+module.exports = {
+  jsonToStructProto,
+  structProtoToJson,
+};

--- a/botlib/test/json_to_proto.js
+++ b/botlib/test/json_to_proto.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const jsonToProto = require('../json_to_proto.js');
+const assert = require('assert');
+
+describe('JsonToProto', () => {
+  const json = {
+    'num': 0,
+    'bool': true,
+    'str': 's',
+    'null': null,
+    'array': [1, '2', true, {}],
+    'obj': {'num': 1, 'str': ''}
+  };
+  const structProto = {
+    'fields': {
+      'num': {'kind': 'numberValue', 'numberValue': 0},
+      'bool': {'kind': 'boolValue', 'boolValue': true},
+      'str': {'kind': 'stringValue', 'stringValue': 's'},
+      'null': {'kind': 'nullValue', 'nullValue': 'NULL_VALUE'},
+      'array': {'kind': 'listValue', 'listValue': {'values': [
+            {'kind': 'numberValue', 'numberValue': 1},
+            {'kind': 'stringValue', 'stringValue': '2'},
+            {'kind': 'boolValue', 'boolValue': true},
+            {'kind': 'structValue', 'structValue': {'fields': {}}}
+          ]}},
+      'obj': {
+        'kind': 'structValue',
+        'structValue': {'fields': {
+            'num': {'kind': 'numberValue', 'numberValue': 1},
+            'str': {'kind': 'stringValue', 'stringValue': ''}
+          }}}
+    }
+  };
+
+  it('should convert JSON to goog.protobuf.Struct', () => {
+    assert.deepEqual(jsonToProto.jsonToStructProto(json), structProto);
+  });
+
+});


### PR DESCRIPTION
# WHY
Normally, the **queryParameters.payload**, which is put in projects.agent.sessions.detectIntent, should be shown in the request that is sent from Dialogflow to the fulfillment webhook. The document states that the payload **CAN BE BOTH ProtoStruct or JSON objects**, but, when the JSON objects was implemented, no payload is received by the webhook. ([session.detectIntent](https://cloud.google.com/dialogflow/docs/reference/rest/v2/projects.agent.sessions/detectIntent#QueryParameters))

After searching for the solution, this problem was once mentioned in this [StackOverflow question](https://stackoverflow.com/questions/51096251/how-to-set-a-custom-platform-in-dialogflow-nodejs-client). It seems that converting the queryParameters.payload from JSON objects to Struct solves the issue. So, this pull request is proposed to implement this solution to the dialogflow-integration server.

# WHAT
*  **Add jsonToProto function which used to convert JSON objects to StructProto** (the code was copied from [matthewayne repo](https://gist.github.com/matthewayne/e9dbd9a428420c3af399cb03d6b526b9)). 
*  **Add the unit test for jsonToProto function** (the mock input and expected output used in the unit test for protoToJson function are used here as well). 
*  **Implement jsonToProto function to the `queryParams.payload` field in `DialogflowSessionClient.constructRequest`** (this change will convert payload from JSON object to ProtoStruct and solve the mentioned issue).