### PR TITLE
Support for other content types in Twilio integration

### DIFF
--- a/twilio/server.js
+++ b/twilio/server.js
@@ -45,8 +45,19 @@ const listener = app.listen(process.env.PORT, function() {
 
 app.post('/', async function(req, res) {
   const body = req.body;
-  const text = body.Body;
   const id = body.From;
+  let text = body.Body;
+
+  // Support for other content types
+  if (text.length == 0) {
+    // Check if location or media
+    if (body.Latitude && body.Longitude) {
+      text = 'geoLocation';
+    } else if (parseInt(body.NumMedia, 10) > 0) {
+      text = body.MediaContentType0;
+    }
+  }
+
   const dialogflowResponse = (await sessionClient.detectIntent(
       text, id, body)).fulfillmentText;
   const twiml = new  MessagingResponse();


### PR DESCRIPTION
Twilio accepts location and media sharing from a platform like [WhatsApp](https://www.twilio.com/docs/sms/whatsapp/tutorial/send-and-receive-media-messages-whatsapp-nodejs). When this content comes in, the `body.Body` parameter is left empty and additional parameters are added for these content types. Dialogflow however, can't process an empty body content, hence the request fails.

For this purpose, if location is shared, we should pass `geoLocation` in the `body` parameter; if it's any other media type, we get the type from `MediaContentType0` and pass that.

Then, on Dialogflow side, we process this information by providing training data that matches e.g. geolocation, image/jpeg, audio/mp3, application/pdf...etc. And we read additional information through the fulfillment in `req.originalDetectIntentRequest.payload` e.g. `req.originalDetectIntentRequest.payload.MediaUrl0`.