### PR TITLE
Twilio SMS integration fulfillment messages support

### DIFF
--- a/twilio/server.js
+++ b/twilio/server.js
@@ -47,10 +47,13 @@ app.post('/', async function(req, res) {
   const body = req.body;
   const text = body.Body;
   const id = body.From;
-  const dialogflowResponse = (await sessionClient.detectIntent(
-      text, id, body)).fulfillmentText;
+
+  const dialogflowResponse = (await sessionClient.detectIntent(text, id, body)).fulfillmentMessages;
+  const tw = dialogflowResponse.find((m) => m.platform === 'PLATFORM_UNSPECIFIED');
+  const msg = tw.text.text[0];
+
   const twiml = new  MessagingResponse();
-  const message = twiml.message(dialogflowResponse);
+  const message = twiml.message(msg);
   res.send(twiml.toString());
 });
 


### PR DESCRIPTION
Hi there.
There was a bug with the integration, as the server would always send the content of the `fulfillmentText` property of the Dialogflow payload instead of the more adequate element from the `fulfillmentMessages` array, that contains the right response from the fulfillment hook. 
For the integration to work properly, the fulfillment response must contain an element in the `fulfillmentMessages` array as follows:

```
[{
      text: {
        text: [raw_text]
      },
      platform: 'PLATFORM_UNSPECIFIED'
}]  
```

This way, the integration will always send the proper message, no matter if it comes from a fulfillment hook, or from Dialogflow itself.