### PR TITLE
Add rich responses for Slack integration with Dialogflow CX

### DIFF
--- a/cx/slack/README.md
+++ b/cx/slack/README.md
@@ -62,7 +62,7 @@ You can view a list of your active integration deployments under [Cloud Run](htt
     *   To do this first click "Add dialogue option" in a fulfillment editing panel.
     *   Then copy and paste the bottom code and edit it to include your chosen elements in the blocks.
         *   { "blocks": [ {...} ] }
-    *   For more information on the layouts for Slack rich messages, please visit https://api.slack.com/messaging/composing/layouts.
+    *   For more information on the layouts for rich messages on Slack, please visit https://api.slack.com/messaging/composing/layouts.
 *   There are two ways to test the integration:
     *   Directly instant message the integration through the Slack App you created.
     *   Install your Slack App on a channal and mention the name of the Slack App (Ex: @appName) in your message.

--- a/cx/slack/README.md
+++ b/cx/slack/README.md
@@ -58,6 +58,10 @@ You can view a list of your active integration deployments under [Cloud Run](htt
 **Testing the Integration**
 
 *   You have now completed all the necessary steps and can test your integration.
+*   To test rich messages you have to first input in the cutom payload for your agent:
+    *   { "blocks": [ {...} ] } for [images](https://api.slack.com/reference/block-kit/block-elements#image)
+    *   {"text": "...", "attachments": [ {...} ] } for attachments such as [buttons](https://api.slack.com/legacy/message-buttons)
+    *   For more information on the layouts for Slack rich messages, please visit https://api.slack.com/messaging/composing/layouts.
 *   There are two ways to test the integration:
 *   1. Directly instant message the integration through the Slack App you created.
 *   2. Install your Slack App on a channal and mention the name of the Slack App (Ex: @appName) in your message.

--- a/cx/slack/README.md
+++ b/cx/slack/README.md
@@ -58,10 +58,11 @@ You can view a list of your active integration deployments under [Cloud Run](htt
 **Testing the Integration**
 
 *   You have now completed all the necessary steps and can test your integration.
-*   To test rich messages you have to first input in the cutom payload for your agent:
-    *   { "blocks": [ {...} ] } for [images](https://api.slack.com/reference/block-kit/block-elements#image)
-    *   {"text": "...", "attachments": [ {...} ] } for attachments such as [buttons](https://api.slack.com/legacy/message-buttons)
+*   To test rich messages you have to first input in the [custom payload](https://cloud.google.com/dialogflow/cx/docs/concept/fulfillment) for your agent:
+    *   To do this first click "Add dialogue option" in a fulfillment editing panel.
+    *   Then copy and paste the bottom code and edit it to include your chosen elements in the blocks.
+        *   { "blocks": [ {...} ] }
     *   For more information on the layouts for Slack rich messages, please visit https://api.slack.com/messaging/composing/layouts.
 *   There are two ways to test the integration:
-*   1. Directly instant message the integration through the Slack App you created.
-*   2. Install your Slack App on a channal and mention the name of the Slack App (Ex: @appName) in your message.
+    *   Directly instant message the integration through the Slack App you created.
+    *   Install your Slack App on a channal and mention the name of the Slack App (Ex: @appName) in your message.

--- a/cx/slack/package.json
+++ b/cx/slack/package.json
@@ -11,7 +11,6 @@
     "@google-cloud/dialogflow-cx": "2.7.0",
     "@slack/events-api": "^2.3.4",
     "@slack/web-api": "^5.15.0",
-    "body-parser": "^1.19.0",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "nodemon": "^2.0.7"

--- a/cx/slack/server.js
+++ b/cx/slack/server.js
@@ -81,10 +81,8 @@ async function convertToSlackMessage(responses, channel_id) {
             break;
  
             /**
-             * For image responses the message format can be found
-             * at https://api.slack.com/reference/block-kit/block-elements#image
-             * For button responses the message format can be found at
-             * https://api.slack.com/legacy/message-buttons
+             * For information on the layouts for rich messages on Slack,
+             * please visit https://api.slack.com/messaging/composing/layouts
              */
             case response.hasOwnProperty('payload'): {
                 reply = await structProtoToJson(response.payload);

--- a/cx/slack/server.js
+++ b/cx/slack/server.js
@@ -61,7 +61,7 @@ async function detectIntentResponse(slackRequest) {
     
     request = slackToDetectIntent(slackRequest, sessionPath);
     const [response] = await client.detectIntent(request);
-    
+
     return response;
 };
 
@@ -79,7 +79,12 @@ async function convertToSlackMessage(responses, channel_id) {
                 };  
             }
             break;
-            
+            /**
+             * For image responses the message format can be found
+             * at https://api.slack.com/reference/block-kit/block-elements#image
+             * For button responses the message format can be found at
+             * https://api.slack.com/legacy/message-buttons
+             */
             case response.hasOwnProperty('payload'): {
                 var output = structProtoToJson(response.payload)
                 if(response.payload.fields.hasOwnProperty('image_url')){

--- a/cx/slack/server.js
+++ b/cx/slack/server.js
@@ -58,7 +58,7 @@ async function detectIntentResponse(slackRequest) {
         sessionId
     );
     console.info(sessionPath);
-    
+
     request = slackToDetectIntent(slackRequest, sessionPath);
     const [response] = await client.detectIntent(request);
 
@@ -67,10 +67,10 @@ async function detectIntentResponse(slackRequest) {
 
 async function convertToSlackMessage(responses, channel_id) {
     let replies = [];
-    
+
     for(let response of responses.queryResult.responseMessages) {
         let reply;
-        
+
         switch(true) {
             case response.hasOwnProperty('text'): {
                 reply = {
@@ -98,14 +98,14 @@ async function convertToSlackMessage(responses, channel_id) {
                 } 
             }
             break;
-            
+
             default:
         }
         if (reply) {
             replies.push(reply);
         }
     }
-        
+
     return replies;
 }
 

--- a/cx/slack/server.js
+++ b/cx/slack/server.js
@@ -79,6 +79,7 @@ async function convertToSlackMessage(responses, channel_id) {
                 };  
             }
             break;
+ 
             /**
              * For image responses the message format can be found
              * at https://api.slack.com/reference/block-kit/block-elements#image
@@ -86,16 +87,8 @@ async function convertToSlackMessage(responses, channel_id) {
              * https://api.slack.com/legacy/message-buttons
              */
             case response.hasOwnProperty('payload'): {
-                var output = structProtoToJson(response.payload)
-                if(response.payload.fields.hasOwnProperty('image_url')){
-                    reply = {
-                        channel: channel_id,
-                        blocks: [output]
-                    }
-                }else if(response.payload.fields.hasOwnProperty('attachments')){
-                    reply = output
-                    reply['channel'] = channel_id
-                } 
+                reply = await structProtoToJson(response.payload);
+                reply['channel'] = channel_id;
             }
             break;
 

--- a/cx/slack/test/server_test.js
+++ b/cx/slack/test/server_test.js
@@ -58,11 +58,10 @@ describe('convertToSlackMessage()', () => {
                 payload: {
                     fields: {    
                         "blocks":{"listValue":{"values":[{"structValue":{"fields":{
-                            "type":{"stringValue":"image","kind":"stringValue"},
-                            "image_url":{"stringValue":"http://example.com/image",
-                            "kind":"stringValue"},
-                            "alt_text":{"stringValue":"Example image.","kind":"stringValue"}}},
-                        "kind":"structValue"}]},"kind":"listValue"}
+                            "type":{"stringValue":"image", "kind":"stringValue"},
+                            "image_url":{"stringValue":"http://example.com/image", "kind":"stringValue"},
+                            "alt_text":{"stringValue":"Example image.", "kind":"stringValue"}}},
+                        "kind":"structValue"}]}, "kind":"listValue"}
                     }
                 }
             }]
@@ -103,27 +102,27 @@ describe('convertToSlackMessage()', () => {
                     fields: {
                         "blocks":{"listValue":{"values":[
                             {"structValue":{"fields":{
-                                "type":{"stringValue":"section","kind":"stringValue"},
+                                "type":{"stringValue":"section", "kind":"stringValue"},
                                 "text":{"structValue":{"fields":{
-                                    "text":{"stringValue":"This is a section block with a button.","kind":"stringValue"},
-                                    "type":{"stringValue":"mrkdwn","kind":"stringValue"}}},
+                                    "text":{"stringValue":"This is a section block with a button.", "kind":"stringValue"},
+                                    "type":{"stringValue":"mrkdwn", "kind":"stringValue"}}},
                                 "kind":"structValue"}}},
                             "kind":"structValue"},
                             {"structValue":{"fields":{
-                                "block_id":{"stringValue":"actionblock","kind":"stringValue"},
-                                "type":{"stringValue":"actions","kind":"stringValue"},
+                                "block_id":{"stringValue":"actionblock", "kind":"stringValue"},
+                                "type":{"stringValue":"actions", "kind":"stringValue"},
                                 "elements":{"listValue":{"values":[
                                     {"structValue":{"fields":{
-                                        "url":{"stringValue":"https://example.com/","kind":"stringValue"},
+                                        "url":{"stringValue":"https://example.com/", "kind":"stringValue"},
                                         "text":{"structValue":{"fields":{
-                                            "type":{"stringValue":"plain_text","kind":"stringValue"},
-                                            "text":{"stringValue":"Link Button","kind":"stringValue"}}},
+                                            "type":{"stringValue":"plain_text", "kind":"stringValue"},
+                                            "text":{"stringValue":"Link Button", "kind":"stringValue"}}},
                                         "kind":"structValue"},
-                                        "type":{"stringValue":"button","kind":"stringValue"}}},
+                                        "type":{"stringValue":"button", "kind":"stringValue"}}},
                                     "kind":"structValue"}]},
                                 "kind":"listValue"}}},
                             "kind":"structValue"}]}
-                        ,"kind":"listValue"}
+                        , "kind":"listValue"}
                     }
                 }
             }]

--- a/cx/slack/test/server_test.js
+++ b/cx/slack/test/server_test.js
@@ -43,11 +43,13 @@ describe('convertToSlackMessage()', () => {
 
     const slackImageRequest = [{
         channel: channel_id,
-        blocks: [{
-            type: "image",
-            image_url: "http://example.com/image",
-            alt_text: "Example image."
-        }]
+        blocks: [
+            {
+                type: "image",
+                image_url: "http://example.com/image",
+                alt_text: "Example image."
+            }
+        ]
     }];
 
     const dialogflowImageResponse = {
@@ -69,45 +71,59 @@ describe('convertToSlackMessage()', () => {
 
     const slackButtonRequest = [{
         channel: channel_id,
-        text: "Would you like to play a game?",
-        attachments: [
+    	blocks: [
             {
-                text: "Choose a game to play",
-                fallback: "You are unable to choose a game",
-                callback_id: "wopr_game",
-                color: "#3AA3E3",
-                attachment_type: "default",
-                actions: [
+                type: "section",
+                text: {
+                    type: "mrkdwn",
+                    text: "This is a section block with a button."
+                }
+            },
+            {
+                type: "actions",
+                block_id: "actionblock",
+                elements: [
                     {
-                        name: "game",
-                        text: "Chess",
                         type: "button",
-                        value: "chess"
+                        text: {
+                            type: "plain_text",
+                            text: "Link Button"
+                        },
+                        url: "https://example.com/"
                     }
                 ]
             }
-        ]
+	    ]
     }]
 
     const dialogflowButtonResponse = {
         queryResult: {
             responseMessages: [{    
                 payload: {
-                    fields: {    
-                        "text":{"stringValue":"Would you like to play a game?","kind":"stringValue"},
-                        "attachments":{"listValue":{"values":[{"structValue":{"fields":{
-                            "callback_id":{"stringValue":"wopr_game","kind":"stringValue"},
-                            "color":{"stringValue":"#3AA3E3","kind":"stringValue"},
-                            "actions":{"listValue":{"values":[{"structValue":{"fields":{
-                                "text":{"stringValue":"Chess","kind":"stringValue"},
-                                "name":{"stringValue":"game","kind":"stringValue"},
-                                "value":{"stringValue":"chess","kind":"stringValue"},
-                                "type":{"stringValue":"button","kind":"stringValue"}}},
-                            "kind":"structValue"}]},"kind":"listValue"},
-                            "fallback":{"stringValue":"You are unable to choose a game","kind":"stringValue"},
-                            "attachment_type":{"stringValue":"default","kind":"stringValue"},
-                            "text":{"stringValue":"Choose a game to play","kind":"stringValue"}}},
-                        "kind":"structValue"}]},"kind":"listValue"}
+                    fields: {
+                        "blocks":{"listValue":{"values":[
+                            {"structValue":{"fields":{
+                                "type":{"stringValue":"section","kind":"stringValue"},
+                                "text":{"structValue":{"fields":{
+                                    "text":{"stringValue":"This is a section block with a button.","kind":"stringValue"},
+                                    "type":{"stringValue":"mrkdwn","kind":"stringValue"}}},
+                                "kind":"structValue"}}},
+                            "kind":"structValue"},
+                            {"structValue":{"fields":{
+                                "block_id":{"stringValue":"actionblock","kind":"stringValue"},
+                                "type":{"stringValue":"actions","kind":"stringValue"},
+                                "elements":{"listValue":{"values":[
+                                    {"structValue":{"fields":{
+                                        "url":{"stringValue":"https://example.com/","kind":"stringValue"},
+                                        "text":{"structValue":{"fields":{
+                                            "type":{"stringValue":"plain_text","kind":"stringValue"},
+                                            "text":{"stringValue":"Link Button","kind":"stringValue"}}},
+                                        "kind":"structValue"},
+                                        "type":{"stringValue":"button","kind":"stringValue"}}},
+                                    "kind":"structValue"}]},
+                                "kind":"listValue"}}},
+                            "kind":"structValue"}]}
+                        ,"kind":"listValue"}
                     }
                 }
             }]
@@ -119,7 +135,7 @@ describe('convertToSlackMessage()', () => {
         assert.deepStrictEqual(request, slackTextRequest); 
     });
 
-    it('Should convert detectIntent Image response to a Slack message request.', async function () {
+    it('Should convert detectIntent image response to a Slack message request.', async function () {
         var request = await convertToSlackMessage(dialogflowImageResponse, channel_id);
         assert.deepStrictEqual(request, slackImageRequest)    
     });

--- a/cx/slack/test/server_test.js
+++ b/cx/slack/test/server_test.js
@@ -1,4 +1,4 @@
-const detectIntentToSlackMessage = require('../server.js').detectIntentToSlackMessage;
+const convertToSlackMessage = require('../server.js').convertToSlackMessage;
 const slackToDetectIntent = require('../server.js').slackToDetectIntent;
 const assert = require('assert');
 
@@ -23,28 +23,57 @@ describe('slackToDetectIntent()', () => {
     });
 });
 
-describe('detectIntentToSlackMessage()', () => {
+describe('convertToSlackMessage()', () => {
     channel_id = 54321
 
-    const slackRequest = {
+    const slackTextRequest = [{
         channel: channel_id,
-        text: 'Test Response Text\n'
-    };
+        text: 'Test Response Text'
+    }];
 
-    const dialogflowResponse = {
+    const dialogflowTextResponse = {
         queryResult: {
-            text: 'Test Text',
-            languageCode: 'en',
             responseMessages: [{
                 text: {
-                    text: 'Test Response Text'
+                    text: ['Test Response Text']
                 }
             }]
         }
     };
 
+    const slackPayloadRequest = [{
+        channel: channel_id,
+        blocks: [{
+            type: "image",
+            image_url: "http://example.com/image",
+            alt_text: "Example image."
+        }]
+    }];
+
+    const dialogflowPayloadResponse = {
+        queryResult: {
+            responseMessages: [{    
+                payload: {
+                    fields: {    
+                        type: { stringValue: 'image', kind: 'stringValue' },
+                        image_url: {
+                            stringValue: 'http://example.com/image',
+                            kind: 'stringValue'
+                        },
+                        alt_text: { stringValue: 'Example image.', kind: 'stringValue' }
+                    }
+                }
+            }]
+        }
+    };    
+
     it('should convert detectIntent response to a Slack text message request.', async function () {
-        assert.deepStrictEqual(detectIntentToSlackMessage(
-            dialogflowResponse, channel_id), slackRequest)
+        var request =  await convertToSlackMessage(dialogflowTextResponse, channel_id);
+        assert.deepStrictEqual(request, slackTextRequest); 
+    });
+
+    it('should convert detectIntent payload response to a Slack message request.', async function () {
+        var request = await convertToSlackMessage(dialogflowPayloadResponse, channel_id);
+        assert.deepStrictEqual(request, slackPayloadRequest)    
     });
 });

--- a/cx/slack/test/server_test.js
+++ b/cx/slack/test/server_test.js
@@ -41,7 +41,7 @@ describe('convertToSlackMessage()', () => {
         }
     };
 
-    const slackPayloadRequest = [{
+    const slackImageRequest = [{
         channel: channel_id,
         blocks: [{
             type: "image",
@@ -50,30 +50,82 @@ describe('convertToSlackMessage()', () => {
         }]
     }];
 
-    const dialogflowPayloadResponse = {
+    const dialogflowImageResponse = {
         queryResult: {
             responseMessages: [{    
                 payload: {
                     fields: {    
-                        type: { stringValue: 'image', kind: 'stringValue' },
-                        image_url: {
-                            stringValue: 'http://example.com/image',
-                            kind: 'stringValue'
-                        },
-                        alt_text: { stringValue: 'Example image.', kind: 'stringValue' }
+                        "blocks":{"listValue":{"values":[{"structValue":{"fields":{
+                            "type":{"stringValue":"image","kind":"stringValue"},
+                            "image_url":{"stringValue":"http://example.com/image",
+                            "kind":"stringValue"},
+                            "alt_text":{"stringValue":"Example image.","kind":"stringValue"}}},
+                        "kind":"structValue"}]},"kind":"listValue"}
                     }
                 }
             }]
         }
     };    
 
-    it('should convert detectIntent response to a Slack text message request.', async function () {
+    const slackButtonRequest = [{
+        channel: channel_id,
+        text: "Would you like to play a game?",
+        attachments: [
+            {
+                text: "Choose a game to play",
+                fallback: "You are unable to choose a game",
+                callback_id: "wopr_game",
+                color: "#3AA3E3",
+                attachment_type: "default",
+                actions: [
+                    {
+                        name: "game",
+                        text: "Chess",
+                        type: "button",
+                        value: "chess"
+                    }
+                ]
+            }
+        ]
+    }]
+
+    const dialogflowButtonResponse = {
+        queryResult: {
+            responseMessages: [{    
+                payload: {
+                    fields: {    
+                        "text":{"stringValue":"Would you like to play a game?","kind":"stringValue"},
+                        "attachments":{"listValue":{"values":[{"structValue":{"fields":{
+                            "callback_id":{"stringValue":"wopr_game","kind":"stringValue"},
+                            "color":{"stringValue":"#3AA3E3","kind":"stringValue"},
+                            "actions":{"listValue":{"values":[{"structValue":{"fields":{
+                                "text":{"stringValue":"Chess","kind":"stringValue"},
+                                "name":{"stringValue":"game","kind":"stringValue"},
+                                "value":{"stringValue":"chess","kind":"stringValue"},
+                                "type":{"stringValue":"button","kind":"stringValue"}}},
+                            "kind":"structValue"}]},"kind":"listValue"},
+                            "fallback":{"stringValue":"You are unable to choose a game","kind":"stringValue"},
+                            "attachment_type":{"stringValue":"default","kind":"stringValue"},
+                            "text":{"stringValue":"Choose a game to play","kind":"stringValue"}}},
+                        "kind":"structValue"}]},"kind":"listValue"}
+                    }
+                }
+            }]
+        }
+    }
+
+    it('Should convert detectIntent text response to a Slack message request.', async function () {
         var request =  await convertToSlackMessage(dialogflowTextResponse, channel_id);
         assert.deepStrictEqual(request, slackTextRequest); 
     });
 
-    it('should convert detectIntent payload response to a Slack message request.', async function () {
-        var request = await convertToSlackMessage(dialogflowPayloadResponse, channel_id);
-        assert.deepStrictEqual(request, slackPayloadRequest)    
+    it('Should convert detectIntent Image response to a Slack message request.', async function () {
+        var request = await convertToSlackMessage(dialogflowImageResponse, channel_id);
+        assert.deepStrictEqual(request, slackImageRequest)    
+    });
+
+    it('Should convert detectIntent button response to a Slack message request.', async function () {
+        var request =  await convertToSlackMessage(dialogflowButtonResponse, channel_id);
+        assert.deepStrictEqual(request, slackButtonRequest)  
     });
 });


### PR DESCRIPTION
This update to the existing Slack-CX Integration will make it so that it is able to accept custom payload responses for Dialogflow as well as text responses.