### PR TITLE
Fix race condition when deleting webhooks and potential error when calling detectIntent

### DIFF
--- a/twitter/server.js
+++ b/twitter/server.js
@@ -167,7 +167,7 @@ function listWebhooks(url) {
                   environment.webhooks.filter((value, index, arr) => {
                     return value.url === url;
                   });
-              resolve(webhooks)
+              resolve(webhooks);
             }
             resolve([]);
           }
@@ -183,9 +183,9 @@ function deleteWebhookById(webhookId) {
         {oauth: twitterOAuth}, function(err, resp, body) {
           if (err) {
             console.error('Failed to delete webhook: ' + err);
-            reject(err)
+            reject(err);
           }
-          resolve()
+          resolve();
         });
   });
 }


### PR DESCRIPTION
Fixed race conditon when deleting webhooks.
Also when the ES integration was @ed to posts it was calling detectIntent with the entire text including the @, so detectIntent was receiving for example "@CXBot hello" instead of just "Hello". I have implemented the same solution that I did for the twitter CX integration which was to replace the @ + screenName with an empty string.