### PR TITLE
Update authentication instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ Follow the steps below to create a Service Account and set up the integration.
 1. Go into the Dialogflow agent’s settings and click on the Project ID link to open its associated GCP Project.
 2. Click on the navigation menu in the GCP console, hover over "IAM & admin", and click "Service accounts". 
 3. Click on "+ CREATE SERVICE ACCOUNT", fill in the details, and give it the "Dialogflow Client API" role.
-4. Click on "+ Create Key" and download the resulting JSON key file. 
-5. Save the JSON key file in the desired platform subdirectory. 
 
-If deploying this integration outside of GCP Cloud Run, it may be necessary to set the GOOGLE_APPLICATION_CREDENTIALS environmental variable on the deployment environment to the absolute path of Service Account JSON key file. See [this guide](https://cloud.google.com/dialogflow/docs/quick/setup#auth) for details.
+If deploying this integration outside of GCP, you may authenticate using a key file. Deploying on Cloud Run or Cloud Functions obviates this process.
+1. Click on "+ Create Key" and download the resulting JSON key file. 
+2. Save the JSON key file in the desired platform subdirectory. 
+3. Set the GOOGLE_APPLICATION_CREDENTIALS environmental variable on the deployment environment to the absolute path of Service Account JSON key file. See [this guide](https://cloud.google.com/dialogflow/docs/quick/setup#auth) for details.
 
 ## Deploying the Integration
 

--- a/cm/README.md
+++ b/cm/README.md
@@ -36,10 +36,10 @@ Run the following command to save the state of your repository into [GCP Contain
 gcloud builds submit --tag gcr.io/PROJECT-ID/dialogflow-cm
 ```
 
-Deploy your integration to live using the following command. Replace PROJECT-ID with your agent’s GCP project Id, and YOUR_KEY_FILE with the name (not path) of your Service Account JSON key file which you acquired in the Service Account Setup step of the [main README file](../readme.md).
+Deploy your integration to Cloud Run using the following command. Replace `PROJECT_ID` with your agent’s GCP project Id, and `DIALOGFLOW_SERIVCE_ACCOUNT` with the Service Account which you acquired in the Service Account Setup step of the [main README file](../readme.md).
 
 ```shell
-gcloud beta run deploy --image gcr.io/PROJECT-ID/dialogflow-cm --update-env-vars GOOGLE_APPLICATION_CREDENTIALS=YOUR_KEY_FILE --memory 1Gi
+gcloud beta run deploy --image gcr.io/PROJECT_ID/dialogflow-cm --service--acount DIALOGFLOW_SERVICE_ACCOUNT --memory 1Gi
 ```
 
 - When prompted for a target platform, select a platform by entering the corresponding number (for example, ``1`` for ``Cloud Run (fully managed)``).

--- a/cm/server.js
+++ b/cm/server.js
@@ -26,12 +26,6 @@ const dialogflowSessionClient = require('../botlib/dialogflow_session_client');
 
 app.use(express.json());
 
-//For authenticating dialogflow_session_client.js, create a Service Account and
-// download its key file. Set the environmental variable
-// GOOGLE_APPLICATION_CREDENTIALS to the key file's location.
-//See https://dialogflow.com/docs/reference/v2-auth-setup and
-// https://cloud.google.com/dialogflow/docs/setup for details.
-
 const cmMessagingApi = new messagingApi.MessageApiClient(cmProductToken);
 const sessionClient = new dialogflowSessionClient(projectId);
 

--- a/cx/discord/README.md
+++ b/cx/discord/README.md
@@ -25,10 +25,10 @@ Run the following command to save the state of your repository into [GCP Contain
 gcloud builds submit --tag gcr.io/PROJECT-ID/dialogflow-PLATFORM
 ```
 
-Deploy your integration to live using the following command. Replace PROJECT-ID with your agent’s GCP project Id, PLATFORM with the platform subdirectory name, and YOUR_KEY_FILE with the name (not path) of your Service Account JSON key file.
+Deploy your integration to Cloud Run using the following command. Replace `PROJECT_ID` with your agent’s GCP project Id, and `DIALOGFLOW_SERIVCE_ACCOUNT` with the Service Account which you acquired in the Service Account Setup step of the [main README file](../readme.md).
 
 ```shell
-gcloud beta run deploy --image gcr.io/PROJECT-ID/dialogflow-PLATFORM --update-env-vars GOOGLE_APPLICATION_CREDENTIALS=YOUR_KEY_FILE --memory 1Gi
+gcloud beta run deploy --image gcr.io/PROJECT_ID/dialogflow-cm --service--acount DIALOGFLOW_SERVICE_ACCOUNT --memory 1Gi
 ```
 
 - When prompted for a target platform, select a platform by entering the corresponding number (for example, ``1`` for ``Cloud Run (fully managed)``).

--- a/cx/slack/README.md
+++ b/cx/slack/README.md
@@ -34,10 +34,10 @@ Run the following command to save the state of your repository into [GCP Contain
 gcloud builds submit --tag gcr.io/PROJECT-ID/dialogflow-PLATFORM
 ```
 
-Deploy your integration to live using the following command. Replace PROJECT-ID with your agent’s GCP project Id, PLATFORM with the platform subdirectory name, and YOUR_KEY_FILE with the name (not path) of your Service Account JSON key file.
+Deploy your integration to Cloud Run using the following command. Replace `PROJECT_ID` with your agent’s GCP project Id, and `DIALOGFLOW_SERIVCE_ACCOUNT` with the Service Account which you acquired in the Service Account Setup step of the [main README file](../readme.md).
 
 ```shell
-gcloud beta run deploy --image gcr.io/PROJECT-ID/dialogflow-PLATFORM --update-env-vars GOOGLE_APPLICATION_CREDENTIALS=YOUR_KEY_FILE --memory 1Gi
+gcloud beta run deploy --image gcr.io/PROJECT_ID/dialogflow-cm --service--acount DIALOGFLOW_SERVICE_ACCOUNT --memory 1Gi
 ```
 
 - When prompted for a target platform, select a platform by entering the corresponding number (for example, ``1`` for ``Cloud Run (fully managed)``).

--- a/cx/spark/README.md
+++ b/cx/spark/README.md
@@ -27,10 +27,10 @@ Run the following command to save the state of your repository into [GCP Contain
 gcloud builds submit --tag gcr.io/PROJECT-ID/dialogflow-PLATFORM
 ```
 
-Deploy your integration to live using the following command. Replace PROJECT-ID with your agent’s GCP project Id, PLATFORM with the platform subdirectory name, and YOUR_KEY_FILE with the name (not path) of your Service Account JSON key file.
+Deploy your integration to Cloud Run using the following command. Replace `PROJECT_ID` with your agent’s GCP project Id, and `DIALOGFLOW_SERIVCE_ACCOUNT` with the Service Account which you acquired in the Service Account Setup step of the [main README file](../readme.md).
 
 ```shell
-gcloud beta run deploy --image gcr.io/PROJECT-ID/dialogflow-PLATFORM --update-env-vars GOOGLE_APPLICATION_CREDENTIALS=YOUR_KEY_FILE --memory 1Gi
+gcloud beta run deploy --image gcr.io/PROJECT_ID/dialogflow-cm --service--acount DIALOGFLOW_SERVICE_ACCOUNT --memory 1Gi
 ```
 
 - When prompted for a target platform, select a platform by entering the corresponding number (for example, ``1`` for ``Cloud Run (fully managed)``).

--- a/cx/spark/server.js
+++ b/cx/spark/server.js
@@ -1,12 +1,3 @@
-/**
- * To-Do:
- * Create a Service Account and download its key file.
- * Set the environmental variable GOOGLE_APPLICATION_CREDENTIALS
- * to the key file's location.
- * See https://cloud.google.com/dialogflow/cx/docs and
- * https://cloud.google.com/dialogflow/cx/docs/quick/setup for details.
- */
-
 const express = require('express');
 const request = require('request');
 const app = express();

--- a/cx/telegram/README.md
+++ b/cx/telegram/README.md
@@ -22,10 +22,10 @@ Run the following command to save the state of your repository into [GCP Contain
 gcloud builds submit --tag gcr.io/PROJECT-ID/dialogflow-PLATFORM
 ```
 
-Deploy your integration to live using the following command. Replace PROJECT-ID with your agent’s GCP project Id, PLATFORM with the platform subdirectory name, and YOUR_KEY_FILE with the name (not path) of your Service Account JSON key file.
+Deploy your integration to Cloud Run using the following command. Replace `PROJECT_ID` with your agent’s GCP project Id, and `DIALOGFLOW_SERIVCE_ACCOUNT` with the Service Account which you acquired in the Service Account Setup step of the [main README file](../readme.md).
 
 ```shell
-gcloud beta run deploy --image gcr.io/PROJECT-ID/dialogflow-PLATFORM --update-env-vars GOOGLE_APPLICATION_CREDENTIALS=YOUR_KEY_FILE --memory 1Gi
+gcloud beta run deploy --image gcr.io/PROJECT_ID/dialogflow-cm --service--acount DIALOGFLOW_SERVICE_ACCOUNT --memory 1Gi
 ```
 
 - When prompted for a target platform, select a platform by entering the corresponding number (for example, ``1`` for ``Cloud Run (fully managed)``).

--- a/cx/twitter/README.md
+++ b/cx/twitter/README.md
@@ -51,10 +51,10 @@ Run the following command to save the state of your repository into [GCP Contain
 gcloud builds submit --tag gcr.io/PROJECT-ID/dialogflow-PLATFORM
 ```
 
-Deploy your integration to live using the following command. Replace PROJECT-ID with your agent’s GCP project Id, PLATFORM with the platform subdirectory name, and YOUR_KEY_FILE with the name (not path) of your Service Account JSON key file.
+Deploy your integration to Cloud Run using the following command. Replace `PROJECT_ID` with your agent’s GCP project Id, and `DIALOGFLOW_SERIVCE_ACCOUNT` with the Service Account which you acquired in the Service Account Setup step of the [main README file](../readme.md).
 
 ```shell
-gcloud beta run deploy --image gcr.io/PROJECT-ID/dialogflow-PLATFORM --update-env-vars GOOGLE_APPLICATION_CREDENTIALS=YOUR_KEY_FILE --memory 1Gi
+gcloud beta run deploy --image gcr.io/PROJECT_ID/dialogflow-cm --service--acount DIALOGFLOW_SERVICE_ACCOUNT --memory 1Gi
 ```
 
 - When prompted for a target platform, select a platform by entering the corresponding number (for example, ``1`` for ``Cloud Run (fully managed)``).

--- a/cx/viber/README.md
+++ b/cx/viber/README.md
@@ -28,10 +28,10 @@ Run the following command to save the state of your repository into [GCP Contain
 gcloud builds submit --tag gcr.io/PROJECT-ID/dialogflow-PLATFORM
 ```
 
-Deploy your integration to live using the following command. Replace PROJECT-ID with your agent’s GCP project Id, PLATFORM with the platform subdirectory name, and YOUR_KEY_FILE with the name (not path) of your Service Account JSON key file.
+Deploy your integration to Cloud Run using the following command. Replace `PROJECT_ID` with your agent’s GCP project Id, and `DIALOGFLOW_SERIVCE_ACCOUNT` with the Service Account which you acquired in the Service Account Setup step of the [main README file](../readme.md).
 
 ```shell
-gcloud beta run deploy --image gcr.io/PROJECT-ID/dialogflow-PLATFORM --update-env-vars GOOGLE_APPLICATION_CREDENTIALS=YOUR_KEY_FILE --memory 1Gi
+gcloud beta run deploy --image gcr.io/PROJECT_ID/dialogflow-cm --service--acount DIALOGFLOW_SERVICE_ACCOUNT --memory 1Gi
 ```
 
 - When prompted for a target platform, select a platform by entering the corresponding number (for example, ``1`` for ``Cloud Run (fully managed)``).

--- a/cx/viber/server.js
+++ b/cx/viber/server.js
@@ -1,11 +1,3 @@
-/**
- * To-Do:
- * Create a Service Account and download its key file.
- * Set the environmental variable GOOGLE_APPLICATION_CREDENTIALS
- * to the key file's location.
- * See https://cloud.google.com/dialogflow/cx/docs and
- * https://cloud.google.com/dialogflow/cx/docs/quick/setup for details.
- */
 const express = require('express');
 const ViberBot = require('viber-bot').Bot;
 const BotEvents = require('viber-bot').Events;

--- a/kik/README.md
+++ b/kik/README.md
@@ -43,10 +43,10 @@ Run the following command to save the state of your repository into [GCP Contain
 gcloud builds submit --tag gcr.io/PROJECT-ID/dialogflow-PLATFORM
 ```
 
-Deploy your integration to live using the following command. Replace PROJECT-ID with your agent’s GCP project Id, PLATFORM with the platform subdirectory name, and YOUR_KEY_FILE with the name (not path) of your Service Account JSON key file.
+Deploy your integration to Cloud Run using the following command. Replace `PROJECT_ID` with your agent’s GCP project Id, and `DIALOGFLOW_SERIVCE_ACCOUNT` with the Service Account which you acquired in the Service Account Setup step of the [main README file](../readme.md).
 
 ```shell
-gcloud beta run deploy --image gcr.io/PROJECT-ID/dialogflow-PLATFORM --update-env-vars GOOGLE_APPLICATION_CREDENTIALS=YOUR_KEY_FILE --memory 1Gi
+gcloud beta run deploy --image gcr.io/PROJECT_ID/dialogflow-cm --service--acount DIALOGFLOW_SERVICE_ACCOUNT --memory 1Gi
 ```
 
 - When prompted for a target platform, select a platform by entering the corresponding number (for example, ``1`` for ``Cloud Run (fully managed)``).

--- a/kik/server.js
+++ b/kik/server.js
@@ -21,12 +21,6 @@ const dialogflowSessionClient =
 const filterResponses = require('../botlib/filter_responses.js');
 const protoToJson = require('../botlib/proto_to_json.js');
 
-//For authenticating dialogflow_session_client.js, create a Service Account and
-// download its key file. Set the environmental variable
-// GOOGLE_APPLICATION_CREDENTIALS to the key file's location.
-//See https://dialogflow.com/docs/reference/v2-auth-setup and
-// https://cloud.google.com/dialogflow/docs/setup for details.
-
 const botName = 'Place kik bot name here';
 const kikApiKey = 'Place kik api key here';
 const webhookUrl = 'Place webhook url here';

--- a/skype/README.md
+++ b/skype/README.md
@@ -32,10 +32,10 @@ Run the following command to save the state of your repository into [GCP Contain
 gcloud builds submit --tag gcr.io/PROJECT-ID/dialogflow-PLATFORM
 ```
 
-Deploy your integration to live using the following command. Replace PROJECT-ID with your agent’s GCP project Id, PLATFORM with the platform subdirectory name, and YOUR_KEY_FILE with the name (not path) of your Service Account JSON key file.
+Deploy your integration to Cloud Run using the following command. Replace `PROJECT_ID` with your agent’s GCP project Id, and `DIALOGFLOW_SERIVCE_ACCOUNT` with the Service Account which you acquired in the Service Account Setup step of the [main README file](../readme.md).
 
 ```shell
-gcloud beta run deploy --image gcr.io/PROJECT-ID/dialogflow-PLATFORM --update-env-vars GOOGLE_APPLICATION_CREDENTIALS=YOUR_KEY_FILE --memory 1Gi
+gcloud beta run deploy --image gcr.io/PROJECT_ID/dialogflow-cm --service--acount DIALOGFLOW_SERVICE_ACCOUNT --memory 1Gi
 ```
 
 - When prompted for a target platform, select a platform by entering the corresponding number (for example, ``1`` for ``Cloud Run (fully managed)``).

--- a/skype/server.js
+++ b/skype/server.js
@@ -24,12 +24,6 @@ const filterResponses = require('../botlib/filter_responses.js');
 const express = require('express');
 const app = express();
 
-//For authenticating dialogflow_session_client.js, create a Service Account and
-// download its key file. Set the environmental variable
-// GOOGLE_APPLICATION_CREDENTIALS to the key file's location.
-//See https://dialogflow.com/docs/reference/v2-auth-setup and
-// https://cloud.google.com/dialogflow/docs/setup for details.
-
 const projectId = 'Place dialogflow project id here';
 const appId = 'Place Microsoft app id here';
 const appPassword = 'Place Microsoft password here';

--- a/spark/README.md
+++ b/spark/README.md
@@ -27,10 +27,10 @@ Run the following command to save the state of your repository into [GCP Contain
 gcloud builds submit --tag gcr.io/PROJECT-ID/dialogflow-PLATFORM
 ```
 
-Deploy your integration to live using the following command. Replace PROJECT-ID with your agent’s GCP project Id, PLATFORM with the platform subdirectory name, and YOUR_KEY_FILE with the name (not path) of your Service Account JSON key file.
+Deploy your integration to Cloud Run using the following command. Replace `PROJECT_ID` with your agent’s GCP project Id, and `DIALOGFLOW_SERIVCE_ACCOUNT` with the Service Account which you acquired in the Service Account Setup step of the [main README file](../readme.md).
 
 ```shell
-gcloud beta run deploy --image gcr.io/PROJECT-ID/dialogflow-PLATFORM --update-env-vars GOOGLE_APPLICATION_CREDENTIALS=YOUR_KEY_FILE --memory 1Gi
+gcloud beta run deploy --image gcr.io/PROJECT_ID/dialogflow-cm --service--acount DIALOGFLOW_SERVICE_ACCOUNT --memory 1Gi
 ```
 
 - When prompted for a target platform, select a platform by entering the corresponding number (for example, ``1`` for ``Cloud Run (fully managed)``).

--- a/spark/server.js
+++ b/spark/server.js
@@ -21,12 +21,6 @@ const dialogflowSessionClient =
 
 app.use(express.json());
 
-// For authenticating dialogflow_session_client.js, create a Service Account and
-// download its key file. Set the environmental variable
-// GOOGLE_APPLICATION_CREDENTIALS to the key file's location.
-// See https://dialogflow.com/docs/reference/v2-auth-setup and
-// https://cloud.google.com/dialogflow/docs/setup for details.
-
 // Upon start a webhook is registered with spark
 // Upon closure the webhook is removed from spark
 

--- a/twilio-ip/README.md
+++ b/twilio-ip/README.md
@@ -32,10 +32,10 @@ Run the following command to save the state of your repository into [GCP Contain
 gcloud builds submit --tag gcr.io/PROJECT-ID/dialogflow-PLATFORM
 ```
 
-Deploy your integration to live using the following command. Replace PROJECT-ID with your agent’s GCP project Id, PLATFORM with the platform subdirectory name, and YOUR_KEY_FILE with the name (not path) of your Service Account JSON key file.
+Deploy your integration to Cloud Run using the following command. Replace `PROJECT_ID` with your agent’s GCP project Id, and `DIALOGFLOW_SERIVCE_ACCOUNT` with the Service Account which you acquired in the Service Account Setup step of the [main README file](../readme.md).
 
 ```shell
-gcloud beta run deploy --image gcr.io/PROJECT-ID/dialogflow-PLATFORM --update-env-vars GOOGLE_APPLICATION_CREDENTIALS=YOUR_KEY_FILE --memory 1Gi
+gcloud beta run deploy --image gcr.io/PROJECT_ID/dialogflow-cm --service--acount DIALOGFLOW_SERVICE_ACCOUNT --memory 1Gi
 ```
 
 - When prompted for a target platform, select a platform by entering the corresponding number (for example, ``1`` for ``Cloud Run (fully managed)``).

--- a/twilio-ip/server.js
+++ b/twilio-ip/server.js
@@ -21,12 +21,6 @@ const AccessToken = require('twilio').jwt.AccessToken;
 const ChatGrant = AccessToken.ChatGrant;
 const Chat = require('twilio-chat');
 
-//For authenticating dialogflow_session_client.js, create a Service Account and
-// download its key file. Set the environmental variable
-// GOOGLE_APPLICATION_CREDENTIALS to the key file's location.
-//See https://dialogflow.com/docs/reference/v2-auth-setup and
-// https://cloud.google.com/dialogflow/docs/setup for details.
-
 const projectId = 'Place your dialogflow projectId here';
 const accountSid = 'Place your accont SID here';
 const apiKey = 'Place your API key here';

--- a/twilio/README.md
+++ b/twilio/README.md
@@ -34,10 +34,10 @@ Run the following command to save the state of your repository into [GCP Contain
 gcloud builds submit --tag gcr.io/PROJECT-ID/dialogflow-PLATFORM
 ```
 
-Deploy your integration to live using the following command. Replace PROJECT-ID with your agent’s GCP project Id, PLATFORM with the platform subdirectory name, and YOUR_KEY_FILE with the name (not path) of your Service Account JSON key file.
+Deploy your integration to Cloud Run using the following command. Replace `PROJECT_ID` with your agent’s GCP project Id, and `DIALOGFLOW_SERIVCE_ACCOUNT` with the Service Account which you acquired in the Service Account Setup step of the [main README file](../readme.md).
 
 ```shell
-gcloud beta run deploy --image gcr.io/PROJECT-ID/dialogflow-PLATFORM --update-env-vars GOOGLE_APPLICATION_CREDENTIALS=YOUR_KEY_FILE --memory 1Gi
+gcloud beta run deploy --image gcr.io/PROJECT_ID/dialogflow-cm --service--acount DIALOGFLOW_SERVICE_ACCOUNT --memory 1Gi
 ```
 
 - When prompted for a target platform, select a platform by entering the corresponding number (for example, ``1`` for ``Cloud Run (fully managed)``).

--- a/twilio/server.js
+++ b/twilio/server.js
@@ -23,12 +23,6 @@ const bodyParser = require('body-parser');
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 
-//For authenticating dialogflow_session_client.js, create a Service Account and
-// download its key file. Set the environmental variable
-// GOOGLE_APPLICATION_CREDENTIALS to the key file's location.
-//See https://dialogflow.com/docs/reference/v2-auth-setup and
-// https://cloud.google.com/dialogflow/docs/setup for details.
-
 const projectId = 'Place your dialogflow projectId here';
 const phoneNumber = "Place your twilio phone number here";
 const accountSid = 'Place your accountSid here';

--- a/twitter/README.md
+++ b/twitter/README.md
@@ -50,10 +50,10 @@ Run the following command to save the state of your repository into [GCP Contain
 gcloud builds submit --tag gcr.io/PROJECT-ID/dialogflow-PLATFORM
 ```
 
-Deploy your integration to live using the following command. Replace PROJECT-ID with your agent’s GCP project Id, PLATFORM with the platform subdirectory name, and YOUR_KEY_FILE with the name (not path) of your Service Account JSON key file.
+Deploy your integration to Cloud Run using the following command. Replace `PROJECT_ID` with your agent’s GCP project Id, and `DIALOGFLOW_SERIVCE_ACCOUNT` with the Service Account which you acquired in the Service Account Setup step of the [main README file](../readme.md).
 
 ```shell
-gcloud beta run deploy --image gcr.io/PROJECT-ID/dialogflow-PLATFORM --update-env-vars GOOGLE_APPLICATION_CREDENTIALS=YOUR_KEY_FILE --memory 1Gi
+gcloud beta run deploy --image gcr.io/PROJECT_ID/dialogflow-cm --service--acount DIALOGFLOW_SERVICE_ACCOUNT --memory 1Gi
 ```
 
 - When prompted for a target platform, select a platform by entering the corresponding number (for example, ``1`` for ``Cloud Run (fully managed)``).

--- a/twitter/server.js
+++ b/twitter/server.js
@@ -23,12 +23,6 @@ const twitterText = require('twitter-text');
 
 app.use(express.json());
 
-//For authenticating dialogflow_session_client.js, create a Service Account and
-// download its key file. Set the environmental variable
-// GOOGLE_APPLICATION_CREDENTIALS to the key file's location.
-//See https://dialogflow.com/docs/reference/v2-auth-setup and
-// https://cloud.google.com/dialogflow/docs/setup for details.
-
 //Upon start a webhook is registered with twitter
 //Upon closure the webhook is removed from twitter
 

--- a/viber/README.md
+++ b/viber/README.md
@@ -27,10 +27,10 @@ Run the following command to save the state of your repository into [GCP Contain
 gcloud builds submit --tag gcr.io/PROJECT-ID/dialogflow-PLATFORM
 ```
 
-Deploy your integration to live using the following command. Replace PROJECT-ID with your agent’s GCP project Id, PLATFORM with the platform subdirectory name, and YOUR_KEY_FILE with the name (not path) of your Service Account JSON key file.
+Deploy your integration to Cloud Run using the following command. Replace `PROJECT_ID` with your agent’s GCP project Id, and `DIALOGFLOW_SERIVCE_ACCOUNT` with the Service Account which you acquired in the Service Account Setup step of the [main README file](../readme.md).
 
 ```shell
-gcloud beta run deploy --image gcr.io/PROJECT-ID/dialogflow-PLATFORM --update-env-vars GOOGLE_APPLICATION_CREDENTIALS=YOUR_KEY_FILE --memory 1Gi
+gcloud beta run deploy --image gcr.io/PROJECT_ID/dialogflow-cm --service--acount DIALOGFLOW_SERVICE_ACCOUNT --memory 1Gi
 ```
 
 - When prompted for a target platform, select a platform by entering the corresponding number (for example, ``1`` for ``Cloud Run (fully managed)``).

--- a/viber/server.js
+++ b/viber/server.js
@@ -24,12 +24,6 @@ const dialogflowSessionClient =
     require('../botlib/dialogflow_session_client.js');
 const app = express();
 
-//For authenticating dialogflow_session_client.js, create a Service Account and
-// download its key file. Set the environmental variable
-// GOOGLE_APPLICATION_CREDENTIALS to the key file's location.
-//See https://dialogflow.com/docs/reference/v2-auth-setup and
-// https://cloud.google.com/dialogflow/docs/setup for details.
-
 const webhookUrl = 'Place webhook url here';
 const projectId = 'Place dialogflow project id here';
 const botName = 'Place Viber bot name here';


### PR DESCRIPTION
The previous instructions recommended downloading and setting a key token file. This is [warned against](https://cloud.google.com/run/docs/securing/service-identity#per-service-identity) and creates unnecessary setup when deploying on GCP.