### PR TITLE
Fix Viber no response crash

### DIFF
--- a/cx/viber/server.js
+++ b/cx/viber/server.js
@@ -49,15 +49,19 @@ const listener = app.listen(port, () => {
 bot.on(BotEvents.MESSAGE_RECEIVED, async (message, response) => {
   const sessionId = response.userProfile.id;
   const dialogflowResponse = await detectIntent(message, sessionId);
-  const reply = await convertToViberMessage(dialogflowResponse);
-  bot.sendMessage(response.userProfile, reply);
+  const replies = await convertToViberMessage(dialogflowResponse);
+  if (replies.length > 0) {
+    bot.sendMessage(response.userProfile, replies);
+  }
 });
 
 bot.on(BotEvents.CONVERSATION_STARTED, async (response) => {
   const sessionId = response.userProfile.id;
   const dialogflowResponse = await detectIntentEvent('VIBER_WELCOME', sessionId);
   const replies = await convertToViberMessage(dialogflowResponse);
-  bot.sendMessage(response.userProfile, replies);
+  if (replies.length > 0) {
+    bot.sendMessage(response.userProfile, replies);
+  }
 });
 
 process.on('SIGTERM', () => {

--- a/viber/server.js
+++ b/viber/server.js
@@ -58,9 +58,9 @@ bot.on(BotEvents.MESSAGE_RECEIVED, async (message, response) => {
   const sessionId = botName;
   const answer = (await sessionClient.detectIntent(
       message.text, sessionId, message)).fulfillmentMessages;
-  const reply = await convertToViberMessage(answer);
-  if (reply) {
-    bot.sendMessage(userProfile, reply);
+  const replies = await convertToViberMessage(answer);
+  if (replies.length) {
+    bot.sendMessage(userProfile, replies);
   }
 });
 
@@ -68,7 +68,9 @@ bot.on(BotEvents.CONVERSATION_STARTED, async (response) => {
   const result = await sessionClient.detectIntentWithEvent('VIBER_WELCOME',
       projectId);
   const replies = await convertToViberMessage(result.fulfillmentMessages);
-  bot.sendMessage(response.userProfile, replies);
+  if (replies.length) {
+    bot.sendMessage(response.userProfile, replies);
+  }
 });
 
 process.on('SIGTERM', () => {


### PR DESCRIPTION
When there is no reply, calling `sendMessage` on an empty array will cause a crash.